### PR TITLE
fix: pubsub_subscription_iam_binding to project id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,6 +126,7 @@ resource "google_logging_organization_sink" "lacework_organization_sink" {
 }
 
 resource "google_pubsub_subscription_iam_binding" "lacework" {
+  project      = local.project_id
   role         = "roles/pubsub.subscriber"
   members      = ["serviceAccount:${local.service_account_json_key.client_email}"]
   subscription = google_pubsub_subscription.lacework_subscription.name

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -128,23 +128,56 @@ update_changelog() {
 load_list_of_changes() {
   latest_version=$(find_latest_version)
   local _list_of_changes=$(git log --no-merges --pretty="* %s (%an)([%h](https://github.com/${org_name}/${project_name}/commit/%H))" ${latest_version}..main)
-  echo "## Features" > CHANGES.md
-  echo "$_list_of_changes" | grep "\* feat[:(]" >> CHANGES.md
-  echo "## Refactor" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* refactor[:(]" >> CHANGES.md
-  echo "## Performance Improvements" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* perf[:(]" >> CHANGES.md
-  echo "## Bug Fixes" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* fix[:(]" >> CHANGES.md
-  echo "## Documentation Updates" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* doc[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* docs[:(]" >> CHANGES.md
-  echo "## Other Changes" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* style[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* chore[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* build[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* ci[:(]" >> CHANGES.md
-  echo "$_list_of_changes" | grep "\* test[:(]" >> CHANGES.md
+
+  # init changes file
+  true > CHANGES.md
+
+  _feat=$(echo "$_list_of_changes" | grep "\* feat[:(]")
+  _refactor=$(echo "$_list_of_changes" | grep "\* refactor[:(]")
+  _perf=$(echo "$_list_of_changes" | grep "\* perf[:(]")
+  _fix=$(echo "$_list_of_changes" | grep "\* fix[:(]")
+  _doc=$(echo "$_list_of_changes" | grep "\* doc[:(]")
+  _docs=$(echo "$_list_of_changes" | grep "\* docs[:(]")
+  _style=$(echo "$_list_of_changes" | grep "\* style[:(]")
+  _chore=$(echo "$_list_of_changes" | grep "\* chore[:(]")
+  _build=$(echo "$_list_of_changes" | grep "\* build[:(]")
+  _ci=$(echo "$_list_of_changes" | grep "\* ci[:(]")
+  _test=$(echo "$_list_of_changes" | grep "\* test[:(]")
+
+  if [ "$_feat" != "" ]; then
+    echo "## Features" >> CHANGES.md
+    echo "$_feat" >> CHANGES.md
+  fi
+
+  if [ "$_refactor" != "" ]; then
+    echo "## Refactor" >> CHANGES.md
+    echo "$_refactor" >> CHANGES.md
+  fi
+
+  if [ "$_perf" != "" ]; then
+    echo "## Performance Improvements" >> CHANGES.md
+    echo "$_perf" >> CHANGES.md
+  fi
+
+  if [ "$_fix" != "" ]; then
+    echo "## Bug Fixes" >> CHANGES.md
+    echo "$_fix" >> CHANGES.md
+  fi
+
+  if [ "${_docs}${_doc}" != "" ]; then
+    echo "## Documentation Updates" >> CHANGES.md
+    if [ "$_doc" != "" ]; then echo "$_doc" >> CHANGES.md; fi
+    if [ "$_docs" != "" ]; then echo "$_docs" >> CHANGES.md; fi
+  fi
+
+  if [ "${_style}${_chore}${_build}${_ci}${_test}" != "" ]; then
+    echo "## Other Changes" >> CHANGES.md
+    if [ "$_style" != "" ]; then echo "$_style" >> CHANGES.md; fi
+    if [ "$_chore" != "" ]; then echo "$_chore" >> CHANGES.md; fi
+    if [ "$_build" != "" ]; then echo "$_build" >> CHANGES.md; fi
+    if [ "$_ci" != "" ]; then echo "$_ci" >> CHANGES.md; fi
+    if [ "$_test" != "" ]; then echo "$_test" >> CHANGES.md; fi
+  fi
 }
 
 generate_release_notes() {


### PR DESCRIPTION
From [Google's documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam#google_pubsub_subscription_iam_binding):
>`project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.

We must use the variable `local.project_id` since users might be
configuring separate projects as well as organization level integration.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>
