### PR TITLE
Feature: Uniform Bucket Level Access and Object Lifecycle Management

### DIFF
--- a/examples/organization-level-audit-log/main.tf
+++ b/examples/organization-level-audit-log/main.tf
@@ -7,4 +7,6 @@ module "gcp_organization_level_audit_log" {
   bucket_force_destroy = true
   org_integration      = true
   organization_id      = "my-organization-id"
+  enable_ubla          = true
+  lifecycle_rule_age   = 7
 }

--- a/examples/project-level-audit-log/main.tf
+++ b/examples/project-level-audit-log/main.tf
@@ -5,4 +5,6 @@ provider "lacework" {}
 module "gcp_organization_level_audit_log" {
   source               = "../../"
   bucket_force_destroy = true
+  enable_ubla          = true
+  lifecycle_rule_age   = 7
 }

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,10 @@ resource "google_storage_bucket" "lacework_bucket" {
   uniform_bucket_level_access = var.enable_ubla
   dynamic "lifecycle_rule" {
     for_each = compact([var.lifecycle_rule_age])
-    content { 
+    content {
       condition {
         age = var.lifecycle_rule_age
-      } 
+      }
       action {
         type = "Delete"
       }

--- a/main.tf
+++ b/main.tf
@@ -58,11 +58,23 @@ module "lacework_at_svc_account" {
 }
 
 resource "google_storage_bucket" "lacework_bucket" {
-  count         = length(var.existing_bucket_name) > 0 ? 0 : 1
-  project       = local.project_id
-  name          = "${var.prefix}-lacework-bucket-${random_id.uniq.hex}"
-  force_destroy = var.bucket_force_destroy
-  depends_on    = [google_project_service.required_apis]
+  count                       = length(var.existing_bucket_name) > 0 ? 0 : 1
+  project                     = local.project_id
+  name                        = "${var.prefix}-lacework-bucket-${random_id.uniq.hex}"
+  force_destroy               = var.bucket_force_destroy
+  depends_on                  = [google_project_service.required_apis]
+  uniform_bucket_level_access = var.enable_ubla
+  dynamic "lifecycle_rule" {
+    for_each = compact([var.lifecycle_rule_age])
+    content { 
+      condition {
+        age = var.lifecycle_rule_age
+      } 
+      action {
+        type = "Delete"
+      }
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "policies" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "required_apis" {
-  type = map
+  type = map(any)
   default = {
     kms               = "cloudkms.googleapis.com"
     dns               = "dns.googleapis.com"
@@ -76,13 +76,13 @@ variable "wait_time" {
 }
 
 variable "enable_ubla" {
-    description = "Boolean for enabled Uniform Bucket Level Access on the audit log bucket"
-    type        = bool
-    default     = false
+  description = "Boolean for enabled Uniform Bucket Level Access on the audit log bucket"
+  type        = bool
+  default     = false
 }
 
 variable "lifecycle_rule_age" {
-    description = "Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely"
-    type        = number
-    default     = null
+  description = "Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely"
+  type        = number
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,3 +74,15 @@ variable "wait_time" {
   default     = "10s"
   description = "Amount of time to wait before the next resource is provisioned."
 }
+
+variable "enable_ubla" {
+    description = "Boolean for enabled Uniform Bucket Level Access on the audit log bucket"
+    type        = bool
+    default     = false
+}
+
+variable "lifecycle_rule_age" {
+    description = "Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely"
+    type        = number
+    default     = null
+}


### PR DESCRIPTION
This PR adds logic for two new settings for the Audit Trail module's Google Cloud Storage Bucket:  Uniform Bucket Level Access and Object Lifecycle Management.

- [Uniform Bucket Level Access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) is a feature that sets a uniform access control list at the bucket level instead of the object level for a Google Cloud Storage bucket.  It is considered a security best practice unless more granular controls are needed, as it prevents individual objects from being exposed publicly without notice.  To avoid any breaking changes, the variable `enable_ubla` defaults to `False`
- [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle) is an automated object lifecycle management feature of Google Cloud Storage that permits an administrator to specify a number of days where objects in a bucket should either be cooled down or deleted.  To avoid any breaking changes, the variable `lifecycle_rule_age` defaults to `null`