### PR TITLE
refactor: update roles used for GCP audit log storage bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,12 +21,14 @@ locals {
     base64decode(module.lacework_at_svc_account.private_key)
   ))
   bucket_roles = {
-    "roles/storage.objectViewer"       = ["serviceAccount:${local.service_account_json_key.client_email}"]
-    "roles/storage.objectCreator"      = [local.logging_sink_writer_identity]
-    "roles/storage.legacyBucketReader" = ["projectViewer:${local.project_id}"]
-    "roles/storage.legacyBucketOwner" = [
+    "roles/storage.admin" = [
       "projectEditor:${local.project_id}",
       "projectOwner:${local.project_id}"
+    ]
+    "roles/storage.objectCreator" = [local.logging_sink_writer_identity]
+    "roles/storage.objectViewer" = [
+      "serviceAccount:${local.service_account_json_key.client_email}",
+      "projectViewer:${local.project_id}"
     ]
   }
 }
@@ -155,9 +157,9 @@ resource "google_storage_notification" "lacework_notification" {
 }
 
 resource "google_project_iam_member" "for_lacework_service_account" {
-  project  = local.project_id
-  role     = "roles/storage.objectViewer"
-  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+  project = local.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
 # wait for X seconds for things to settle down in the GCP side

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "required_apis" {
   type = map(any)
   default = {
-    iam               = "iam.googleapis.com"
-    pubsub            = "pubsub.googleapis.com"
-    serviceusage      = "serviceusage.googleapis.com"
-    resourcemanager   = "cloudresourcemanager.googleapis.com"
+    iam             = "iam.googleapis.com"
+    pubsub          = "pubsub.googleapis.com"
+    serviceusage    = "serviceusage.googleapis.com"
+    resourcemanager = "cloudresourcemanager.googleapis.com"
   }
 }
 


### PR DESCRIPTION
This feature modifies the roles being used in the Google Cloud Storage Bucket for the audit log module by migrating the  `roles/storage.legacyBucketReader` privileges to `roles/storage.objectViewer` and `roles/storage.legacyBucketOwner` to `roles/storage.admin`.  

This will future-proof later releases when we switch to using Uniform Bucket Level Access by default following [Google Cloud recommendations](https://cloud.google.com/storage/docs/access-control/) as these newer roles function with both access levels.