### PR TITLE
fix: Add missing organizationViewer role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,13 @@ resource "google_project_iam_member" "for_lacework_service_account" {
   member  = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
+resource "google_organization_iam_member" "for_lacework_service_account" {
+  count    = var.org_integration ? 1 : 0
+  org_id   = var.organization_id
+  role     = "roles/resourcemanager.organizationViewer"
+  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+}
+
 # wait for X seconds for things to settle down in the GCP side
 # before trying to create the Lacework external integration
 resource "time_sleep" "wait_time" {

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,8 @@ resource "time_sleep" "wait_time" {
     google_storage_notification.lacework_notification,
     google_pubsub_subscription_iam_binding.lacework,
     module.lacework_at_svc_account,
-    google_project_iam_member.for_lacework_service_account
+    google_project_iam_member.for_lacework_service_account,
+    google_organization_iam_member.for_lacework_service_account
   ]
 }
 


### PR DESCRIPTION
Fixes: https://lacework.atlassian.net/browse/ALLY-550

As @afiune has rightly pointed out, the `resourcemanager.organizationViewer` role was missed for the audit log integration during the re-work of the gcp Terraform modules

Signed-off-by: Ross Moles <ross.moles@lacework.net>