### PR TITLE
fix: avoid required lifecycle_rule_age input 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,10 +163,10 @@ resource "google_project_iam_member" "for_lacework_service_account" {
 }
 
 resource "google_organization_iam_member" "for_lacework_service_account" {
-  count    = var.org_integration ? 1 : 0
-  org_id   = var.organization_id
-  role     = "roles/resourcemanager.organizationViewer"
-  member   = "serviceAccount:${local.service_account_json_key.client_email}"
+  count  = var.org_integration ? 1 : 0
+  org_id = var.organization_id
+  role   = "roles/resourcemanager.organizationViewer"
+  member = "serviceAccount:${local.service_account_json_key.client_email}"
 }
 
 # wait for X seconds for things to settle down in the GCP side

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "google_storage_bucket" "lacework_bucket" {
   depends_on                  = [google_project_service.required_apis]
   uniform_bucket_level_access = var.enable_ubla
   dynamic "lifecycle_rule" {
-    for_each = compact([var.lifecycle_rule_age])
+    for_each = var.lifecycle_rule_age > 0 ? [1] : []
     content {
       condition {
         age = var.lifecycle_rule_age

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "enable_ubla" {
 }
 
 variable "lifecycle_rule_age" {
-  description = "Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely"
+  description = "Number of days to keep audit logs in Lacework GCS bucket before deleting. Leave default to keep indefinitely"
   type        = number
-  default     = null
+  default     = -1
 }


### PR DESCRIPTION
This PR is fixing the fact that `lifecycle_rule_age` was marked as required since it was set to `null`:

![Screen Shot 2021-06-22 at 11 01 58 AM](https://user-images.githubusercontent.com/5712253/122976563-bbb5d600-d351-11eb-8ab6-9712292bfb0b.png)
