### PR TITLE
Update TF for bucket region GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cloudresourcemanager.googleapis.com
 |service_account_name|The Service Account name (required when use_existing_service_account is set to true). This can also be used to specify the new service account name when use_existing_service_account is set to false|string|""|false|
 |service_account_private_key|The private key in JSON format, base64 encoded (required when use_existing_service_account is set to true)|string|""|false|
 |existing_bucket_name|The name of an existing bucket you want to send the logs to|string|""|false|
+|bucket_region|The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA). To set single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations|string|US|false|
 |bucket_force_destroy|Whether to force destroy the bucket and ignore any content.|bool|false|false|
 |lacework_integration_name|The integration name displayed in the Lacework UI.|string|TF audit_log|false|
 |required_apis|The APIs that should be enabled for this integration to be successful.|map(any)|See the Required APIs section|false|

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cloudresourcemanager.googleapis.com
 |service_account_name|The Service Account name (required when use_existing_service_account is set to true). This can also be used to specify the new service account name when use_existing_service_account is set to false|string|""|false|
 |service_account_private_key|The private key in JSON format, base64 encoded (required when use_existing_service_account is set to true)|string|""|false|
 |existing_bucket_name|The name of an existing bucket you want to send the logs to|string|""|false|
-|bucket_region|The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA). To set single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations|string|US|false|
+|bucket_region|The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA) alternatively you can set a single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations|string|US|false|
 |bucket_force_destroy|Whether to force destroy the bucket and ignore any content.|bool|false|false|
 |lacework_integration_name|The integration name displayed in the Lacework UI.|string|TF audit_log|false|
 |required_apis|The APIs that should be enabled for this integration to be successful.|map(any)|See the Required APIs section|false|

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ resource "google_storage_bucket" "lacework_bucket" {
   project                     = local.project_id
   name                        = "${var.prefix}-${random_id.uniq.hex}"
   force_destroy               = var.bucket_force_destroy
+  location                    = var.bucket_region
   depends_on                  = [google_project_service.required_apis]
   uniform_bucket_level_access = var.enable_ubla
   dynamic "lifecycle_rule" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "bucket_force_destroy" {
 variable "bucket_region" {
   type        = string
   default     = "US"
-  description = "The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA). To set single region or Dual region follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations "
+  description = "The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA) alternatively you can set a single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations|string|US|false|"
 }
 
 variable "prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "bucket_force_destroy" {
   default = false
 }
 
+variable "bucket_region" {
+  type        = string
+  default     = "US"
+  description = "The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA). To set single region or Dual region follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations "
+}
+
 variable "prefix" {
   type        = string
   default     = "lw-at"


### PR DESCRIPTION
Current deployment only created a bucket in the US region, there needs to be options when creating a bucket to select a region other than the default us. The changes I made just allow for specifying another region eu or asia if needed