### PR TITLE
feat: Add logging block to google_storage_bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ cloudresourcemanager.googleapis.com
 |lifecycle_rule_age|Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely|number|null|false|
 |pubsub_topic_labels|Set of labels which will be added to the topic.|map(string)|null|false|
 |pubsub_subscription_labels|Set of labels which will be added to the subscription.|map(string)|null|false|
+|log_bucket|The name of the bucket that will receive log objects.|string|""|false|
+|log_bucket_location|The location of the log bucket.|string|global|false|
+|log_bucket_retention_days|The number of days to keep logs in log bucket before deleting.|number|30|false|
 
 
 

--- a/examples/project-level-audit-log-with-logging-bucket/README.md
+++ b/examples/project-level-audit-log-with-logging-bucket/README.md
@@ -1,0 +1,27 @@
+# Integrate GCP Project with Lacework
+The following provides an example of integrating a Google Cloud Project with Lacework for Cloud Audit Log analysis with a log bucket configured for logging of the bucket's access & storage Logs.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_audit_log" {
+  source                    = "lacework/audit-log/gcp"
+  version                   = "~> 1.0"
+  bucket_force_destroy      = true
+  log_bucket                = "lacework-log-bucket"
+  log_bucket_location       = "us-east1"
+  log_bucket_retention_days = 60
+}
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://support.lacework.com/hc/en-us/articles/360057065094-GCP-Compliance-and-Audit-Trail-Integration-Terraform-From-Any-Supported-Host)

--- a/examples/project-level-audit-log-with-logging-bucket/main.tf
+++ b/examples/project-level-audit-log-with-logging-bucket/main.tf
@@ -1,0 +1,13 @@
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_audit_log" {
+  source                    = "../../"
+  bucket_force_destroy      = true
+  enable_ubla               = true
+  lifecycle_rule_age        = 7
+  log_bucket                = "lacework-log-bucket"
+  log_bucket_location       = "us-east1"
+  log_bucket_retention_days = 60
+}

--- a/examples/project-level-audit-log-with-logging-bucket/versions.tf
+++ b/examples/project-level-audit-log-with-logging-bucket/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,14 @@ module "lacework_at_svc_account" {
   project_id           = local.project_id
 }
 
+resource "google_logging_project_bucket_config" "lacework_log_bucket" {
+    count          = length(var.log_bucket) > 0 ? 1 : 0
+    project        = local.project_id
+    location       = var.log_bucket_location
+    retention_days = var.log_bucket_retention_days
+    bucket_id      = var.log_bucket
+}
+
 resource "google_storage_bucket" "lacework_bucket" {
   count                       = length(var.existing_bucket_name) > 0 ? 0 : 1
   project                     = local.project_id
@@ -88,6 +96,12 @@ resource "google_storage_bucket" "lacework_bucket" {
     }
   }
   labels = merge(var.labels, var.bucket_labels)
+  dynamic "logging" {
+    for_each = length(var.log_bucket) > 0 ? [1] : []
+      content {
+        log_bucket = var.log_bucket
+    }
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "policies" {

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,21 @@ variable "pubsub_subscription_labels" {
   default     = null
   description = "Set of labels which will be added to the subscription"
 }
+
+variable "log_bucket" {
+  type        = string
+  default     = ""
+  description = "The name of the bucket that will receive log objects"
+}
+
+variable "log_bucket_location" {
+  type        = string
+  default     = "global"
+  description = "The location of the bucket. Default is global"
+}
+
+variable "log_bucket_retention_days" {
+  type        = number
+  default     = 30
+  description = "The number of days to keep logs before deleting. Default is 30"
+}


### PR DESCRIPTION
***Issue***: https://lacework.atlassian.net/browse/ALLY-714

***Description:***
GCP_CIS_5_3 requires rule -> 'ensure logging is enabled on bucket'
This change doesn't enforce logging by default. But does give the ability to set logging and to prevent violation of the above rule.

