### PR TITLE
feat: adding filtering for k8s logs in GCP Audit Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,42 +28,88 @@ pubsub.googleapis.com
 serviceusage.googleapis.com
 cloudresourcemanager.googleapis.com
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.2 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lacework_at_svc_account"></a> [lacework\_at\_svc\_account](#module\_lacework\_at\_svc\_account) | lacework/service-account/gcp | ~> 1.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_logging_organization_sink.lacework_organization_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_organization_sink) | resource |
+| [google_logging_project_bucket_config.lacework_log_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_bucket_config) | resource |
+| [google_logging_project_sink.lacework_project_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_organization_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_project_iam_member.for_lacework_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.required_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_pubsub_subscription.lacework_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription_iam_binding.lacework](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_binding) | resource |
+| [google_pubsub_topic.lacework_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_binding.topic_publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
+| [google_storage_bucket.lacework_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_binding.policies](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
+| [google_storage_notification.lacework_notification](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
+| [lacework_integration_gcp_at.default](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_gcp_at) | resource |
+| [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [google_project.selected](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_storage_project_service_account.lw](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-|org_integration|If set to true, configure an organization level integration|bool|false|false|
-|organization_id|The organization ID, required if org_integration is set to true|string|""|false|
-|project_id|A project ID different from the default defined inside the provider|string|""|false|
-|use_existing_service_account|Set this to true to use an existing Service Account. When using an existing service account, the required roles must be added manually.|bool|false|false|
-|service_account_name|The Service Account name (required when use_existing_service_account is set to true). This can also be used to specify the new service account name when use_existing_service_account is set to false|string|""|false|
-|service_account_private_key|The private key in JSON format, base64 encoded (required when use_existing_service_account is set to true)|string|""|false|
-|existing_bucket_name|The name of an existing bucket you want to send the logs to|string|""|false|
-|existing_sink_name|The name of an existing sink that already captures management events. **Note:** If both `existing_bucket_name` and `existing_sink_name` are configured, this module assumes they are correctly configured for log capture.|string|""|false
-|bucket_region|The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA). Alternatively, you can set a single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations|string|US|false|
-|bucket_force_destroy|Whether to force destroy the bucket and ignore any content.|bool|false|false|
-|bucket_labels|Set of labels which will be added to the audit log bucket.|map(string)|null|false|
-|lacework_integration_name|The integration name displayed in the Lacework UI.|string|TF audit_log|false|
-|required_apis|The APIs that should be enabled for this integration to be successful.|map(any)|See the Required APIs section|false|
-|prefix|The prefix that will be used at the beginning of every generated resource|string|lw-at|false|
-|labels|Set of labels which will be added to the resources managed by the module|map(string)|null|false|
-|wait_time|Amount of time to wait before the next resource is provisioned.|string|10s|false|
-|enable_ubla|Boolean for enabled Uniform Bucket Level Access on the audit log bucket|bool|false|false|
-|lifecycle_rule_age|Number of days to keep audit logs in Lacework GCS bucket before deleting.  Leave null to keep indefinitely|number|null|false|
-|pubsub_topic_labels|Set of labels which will be added to the topic.|map(string)|null|false|
-|pubsub_subscription_labels|Set of labels which will be added to the subscription.|map(string)|null|false|
-|log_bucket|The name of the bucket that will receive log objects.|string|""|false|
-|log_bucket_location|The location of the log bucket.|string|global|false|
-|log_bucket_retention_days|The number of days to keep logs in log bucket before deleting.|number|30|false|
-
-
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | n/a | `bool` | `false` | no |
+| <a name="input_bucket_labels"></a> [bucket\_labels](#input\_bucket\_labels) | Set of labels which will be added to the audit log bucket | `map(string)` | `null` | no |
+| <a name="input_bucket_region"></a> [bucket\_region](#input\_bucket\_region) | The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA) alternatively you can set a single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations\|string\|US\|false\| | `string` | `"US"` | no |
+| <a name="input_enable_ubla"></a> [enable\_ubla](#input\_enable\_ubla) | Boolean for enabled Uniform Bucket Level Access on the audit log bucket | `bool` | `false` | no |
+| <a name="input_existing_bucket_name"></a> [existing\_bucket\_name](#input\_existing\_bucket\_name) | The name of an existing bucket you want to send the logs to | `string` | `""` | no |
+| <a name="input_existing_sink_name"></a> [existing\_sink\_name](#input\_existing\_sink\_name) | The name of an existing sink to be re-used for this integration | `string` | `""` | no |
+| <a name="input_k8s_filter"></a> [k8s\_filter](#input\_k8s\_filter) | Filter out GKE logs from GCP Audit Log sinks.  Default is false | `bool` | `false` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Set of labels which will be added to the resources managed by the module | `map(string)` | `null` | no |
+| <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF audit_log"` | no |
+| <a name="input_lifecycle_rule_age"></a> [lifecycle\_rule\_age](#input\_lifecycle\_rule\_age) | Number of days to keep audit logs in Lacework GCS bucket before deleting. Leave default to keep indefinitely | `number` | `-1` | no |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | The name of the bucket that will receive log objects | `string` | `""` | no |
+| <a name="input_log_bucket_location"></a> [log\_bucket\_location](#input\_log\_bucket\_location) | The location of the bucket. Default is global | `string` | `"global"` | no |
+| <a name="input_log_bucket_retention_days"></a> [log\_bucket\_retention\_days](#input\_log\_bucket\_retention\_days) | The number of days to keep logs before deleting. Default is 30 | `number` | `30` | no |
+| <a name="input_org_integration"></a> [org\_integration](#input\_org\_integration) | If set to true, configure an organization level integration | `bool` | `false` | no |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | The organization ID, required if org\_integration is set to true | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix that will be use at the beginning of every generated resource | `string` | `"lw-at"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | A project ID different from the default defined inside the provider | `string` | `""` | no |
+| <a name="input_pubsub_subscription_labels"></a> [pubsub\_subscription\_labels](#input\_pubsub\_subscription\_labels) | Set of labels which will be added to the subscription | `map(string)` | `null` | no |
+| <a name="input_pubsub_topic_labels"></a> [pubsub\_topic\_labels](#input\_pubsub\_topic\_labels) | Set of labels which will be added to the topic | `map(string)` | `null` | no |
+| <a name="input_required_apis"></a> [required\_apis](#input\_required\_apis) | n/a | `map(any)` | <pre>{<br>  "iam": "iam.googleapis.com",<br>  "pubsub": "pubsub.googleapis.com",<br>  "resourcemanager": "cloudresourcemanager.googleapis.com",<br>  "serviceusage": "serviceusage.googleapis.com"<br>}</pre> | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The Service Account name (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
+| <a name="input_service_account_private_key"></a> [service\_account\_private\_key](#input\_service\_account\_private\_key) | The private key in JSON format, base64 encoded (required when use\_existing\_service\_account is set to true) | `string` | `""` | no |
+| <a name="input_use_existing_service_account"></a> [use\_existing\_service\_account](#input\_use\_existing\_service\_account) | Set this to true to use an existing Service Account | `bool` | `false` | no |
+| <a name="input_wait_time"></a> [wait\_time](#input\_wait\_time) | Amount of time to wait before the next resource is provisioned. | `string` | `"10s"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-|service_account_name|The Service Account name|
-|service_account_private_key|The private key in JSON format, base64 encoded|
-|bucket_name|The storage bucket name|
-|pubsub_topic_name|The PubSub topic name|
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | The storage bucket name |
+| <a name="output_pubsub_topic_name"></a> [pubsub\_topic\_name](#output\_pubsub\_topic\_name) | The PubSub topic name |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | The Service Account name |
+| <a name="output_service_account_private_key"></a> [service\_account\_private\_key](#output\_service\_account\_private\_key) | The private key in JSON format, base64 encoded |
+| <a name="output_sink_name"></a> [sink\_name](#output\_sink\_name) | The sink name |

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,6 @@ variable "log_bucket_retention_days" {
 
 variable "k8s_filter" {
   type        = bool
-  default     = true
-  description = "Filter out GKE logs from GCP Audit Log sinks.  Default is true"
+  default     = false
+  description = "Filter out GKE logs from GCP Audit Log sinks.  Default is false"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,9 @@ variable "log_bucket_retention_days" {
   default     = 30
   description = "The number of days to keep logs before deleting. Default is 30"
 }
+
+variable "k8s_filter" {
+  type        = bool
+  default     = true
+  description = "Filter out GKE logs from GCP Audit Log sinks.  Default is true"
+}


### PR DESCRIPTION
Description:  This pull request adds a new variable, `k8s_filter`, which when set to `true` will add an exclusion filter to the Lacework log sink being created that omits the Kubernetes logs that GKE sends to the Audit Log by default.  This will greatly reduce log volume and egress charges for large GKE shops using Lacework, since we do not process the k8s logs for anomaly detection via these Audit Log integrations.

This variable is set to `true` by default to omit the logs, but can be set to `false` to revert to the original filter.  Additionally, the filter itself has been moved to a local to simplify future changes.

