### PR TITLE
fix(variables): Update GCP audit-log module examples & Set labels vars default to empty map rather than null

### DIFF
--- a/examples/project-level-audit-log-with-logging-bucket/README.md
+++ b/examples/project-level-audit-log-with-logging-bucket/README.md
@@ -14,10 +14,12 @@ provider "google" {}
 
 provider "lacework" {}
 
-module "gcp_organization_level_audit_log" {
+module "gcp_project_level_audit_log" {
   source                    = "lacework/audit-log/gcp"
   version                   = "~> 1.0"
   bucket_force_destroy      = true
+  enable_ubla               = true
+  lifecycle_rule_age        = 7
   log_bucket                = "lacework-log-bucket"
   log_bucket_location       = "us-east1"
   log_bucket_retention_days = 60

--- a/examples/project-level-audit-log-with-logging-bucket/main.tf
+++ b/examples/project-level-audit-log-with-logging-bucket/main.tf
@@ -2,7 +2,7 @@ provider "google" {}
 
 provider "lacework" {}
 
-module "gcp_organization_level_audit_log" {
+module "gcp_project_level_audit_log" {
   source                    = "../../"
   bucket_force_destroy      = true
   enable_ubla               = true

--- a/examples/project-level-audit-log/README.md
+++ b/examples/project-level-audit-log/README.md
@@ -14,10 +14,12 @@ provider "google" {}
 
 provider "lacework" {}
 
-module "gcp_organization_level_audit_log" {
+module "gcp_project_level_audit_log" {
   source               = "lacework/audit-log/gcp"
   version              = "~> 1.0"
   bucket_force_destroy = true
+  enable_ubla          = true
+  lifecycle_rule_age   = 7
 }
 ```
 

--- a/examples/project-level-audit-log/main.tf
+++ b/examples/project-level-audit-log/main.tf
@@ -2,7 +2,7 @@ provider "google" {}
 
 provider "lacework" {}
 
-module "gcp_organization_level_audit_log" {
+module "gcp_project_level_audit_log" {
   source               = "../../"
   bucket_force_destroy = true
   enable_ubla          = true

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "bucket_region" {
 
 variable "bucket_labels" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = "Set of labels which will be added to the audit log bucket"
 }
 
@@ -81,7 +81,7 @@ variable "prefix" {
 
 variable "labels" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = "Set of labels which will be added to the resources managed by the module"
 }
 
@@ -110,13 +110,13 @@ variable "lifecycle_rule_age" {
 
 variable "pubsub_topic_labels" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = "Set of labels which will be added to the topic"
 }
 
 variable "pubsub_subscription_labels" {
   type        = map(string)
-  default     = null
+  default     = {}
   description = "Set of labels which will be added to the subscription"
 }
 


### PR DESCRIPTION

***Issue***: 
https://lacework.atlassian.net/browse/ALLY-825

***Description:***
We have noticed some issues with the current GCP module examples. This is a first pass at tidying this up.
Additionally, this PR updates the default value for label variables to `{}` rather than `null`. This should mean they will not show up as `required` variables in the Terraform Registry
