### PR TITLE
feat: Add project id variable validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,10 @@ variable "project_id" {
   type        = string
   default     = ""
   description = "A project ID different from the default defined inside the provider"
+  validation {
+    condition     = can(regex("(^[a-z][a-z0-9_-]{6,30}[^-]$|^$)", var.project_id))
+    error_message = "The project_id variable must be a valid GCP project ID. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited.. Example: tokyo-rain-123."
+  }
 }
 
 variable "use_existing_service_account" {


### PR DESCRIPTION
## Summary
Add validation of project_id variable to make sure it is actually a valid project id and not, for example, a project number.

## How did you test this change?

Regex testing: regexr.com/6irlr
Manual test with local terraform

## Issue
When providing an invalid project id and, for example, uses the project number this or depending modules might fail with non-specific error messages. 
