### PR TITLE
feat: customize filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ cloudresourcemanager.googleapis.com
 | <a name="input_folders_to_exclude"></a> [folders\_to\_exclude](#input\_folders\_to\_exclude) | List of root folders to exclude in an organization-level integration.  Format is 'folders/1234567890' | `set(string)` | `[]` | no |
 | <a name="input_include_root_projects"></a> [include\_root\_projects](#input\_include\_root\_projects) | Enables logic to include root-level projects if excluding folders.  Default is true | `bool` | `true` | no |
 | <a name="input_k8s_filter"></a> [k8s\_filter](#input\_k8s\_filter) | Filter out GKE logs from GCP Audit Log sinks.  Default is true | `bool` | `true` | no |
+| <a name="input_google_workspace_filter"></a> [google\_workspace\_filter](#input\_google\_workspace\_filter) | Filter out Google Workspace login logs from GCP Audit Log sinks.  Default is false | `bool` | `false` | no |
+| <a name="input_custom_filter"></a> [custom\_filter](#input\_custom\_filter) | Customer defined Audit Log filter which will supersede all other filter options when present | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Set of labels which will be added to the resources managed by the module | `map(string)` | `{}` | no |
 | <a name="input_lacework_integration_name"></a> [lacework\_integration\_name](#input\_lacework\_integration\_name) | n/a | `string` | `"TF audit_log"` | no |
 | <a name="input_lifecycle_rule_age"></a> [lifecycle\_rule\_age](#input\_lifecycle\_rule\_age) | Number of days to keep audit logs in Lacework GCS bucket before deleting. Leave default to keep indefinitely | `number` | `-1` | no |

--- a/examples/org-level-custom-filter/README.md
+++ b/examples/org-level-custom-filter/README.md
@@ -1,0 +1,27 @@
+# Integrate GCP Organization with Lacework
+The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Audit Log analysis using a custom Log Filter provided by the customer.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_audit_log" {
+  source               = "lacework/audit-log/gcp"
+  version              = "~> 3.0"
+  bucket_force_destroy = true
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  custom_filter        = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
+}
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)

--- a/examples/org-level-custom-filter/main.tf
+++ b/examples/org-level-custom-filter/main.tf
@@ -1,0 +1,17 @@
+provider "google" {}
+
+provider "lacework" {}
+
+variable "organization_id" {
+  default = "my-organization-id"
+}
+
+module "gcp_organization_level_audit_log" {
+  source               = "../../"
+  bucket_force_destroy = true
+  org_integration      = true
+  organization_id      = var.organization_id
+  enable_ubla          = true
+  lifecycle_rule_age   = 7
+  custom_filter        = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
+}

--- a/examples/org-level-custom-filter/versions.tf
+++ b/examples/org-level-custom-filter/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/examples/org-level-google-workspace-filter/README.md
+++ b/examples/org-level-google-workspace-filter/README.md
@@ -1,0 +1,27 @@
+# Integrate GCP Organization with Lacework
+The following provides an example of integrating a Google Cloud Organization with Lacework for Cloud Audit Log analysis using a log filter which will filter out Google Workspace events.
+
+```hcl
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}
+
+provider "google" {}
+
+provider "lacework" {}
+
+module "gcp_organization_level_audit_log" {
+  source                    = "lacework/audit-log/gcp"
+  version                   = "~> 3.0"
+  bucket_force_destroy      = true
+  org_integration           = true
+  organization_id           = "my-organization-id"
+  google_workspace_filter   = true
+}
+```
+
+For detailed information on integrating Lacework with Google Cloud see [GCP Compliance and Audit Trail Integration - Terraform From Any Supported Host](https://docs.lacework.com/gcp-compliance-and-audit-log-integration-terraform-from-any-supported-host)

--- a/examples/org-level-google-workspace-filter/main.tf
+++ b/examples/org-level-google-workspace-filter/main.tf
@@ -7,11 +7,11 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
-  google_workspace_filter      = true
+  source                  = "../../"
+  bucket_force_destroy    = true
+  org_integration         = true
+  organization_id         = var.organization_id
+  enable_ubla             = true
+  lifecycle_rule_age      = 7
+  google_workspace_filter = true
 }

--- a/examples/org-level-google-workspace-filter/main.tf
+++ b/examples/org-level-google-workspace-filter/main.tf
@@ -1,0 +1,17 @@
+provider "google" {}
+
+provider "lacework" {}
+
+variable "organization_id" {
+  default = "my-organization-id"
+}
+
+module "gcp_organization_level_audit_log" {
+  source               = "../../"
+  bucket_force_destroy = true
+  org_integration      = true
+  organization_id      = var.organization_id
+  enable_ubla          = true
+  lifecycle_rule_age   = 7
+  google_workspace_filter      = true
+}

--- a/examples/org-level-google-workspace-filter/versions.tf
+++ b/examples/org-level-google-workspace-filter/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ locals {
     default = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\")"
     k8s_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\")"
     workspace_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
-    k8s_workspace_combined = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\" AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
+    k8s_workspace_combined = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\") AND NOT (protoPayload.methodName:\"storage.objects\")"
   }
 
   log_filter = length(var.custom_filter) > 0 ? ( var.custom_filter ) : ( 

--- a/main.tf
+++ b/main.tf
@@ -52,22 +52,22 @@ locals {
   })
 
   log_filter_map = {
-    default = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\")"
-    k8s_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\")"
-    workspace_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
+    default                = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\")"
+    k8s_only               = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\")"
+    workspace_only         = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
     k8s_workspace_combined = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\") AND NOT (protoPayload.methodName:\"storage.objects\")"
   }
 
-  log_filter = length(var.custom_filter) > 0 ? ( var.custom_filter ) : ( 
-      !var.k8s_filter && !var.google_workspace_filter ? ("${lookup(local.log_filter_map, "default")}" ) : (
-        var.k8s_filter && !var.google_workspace_filter ? 
-          "${lookup(local.log_filter_map, "k8s_only")}" : (
-            !var.k8s_filter && var.google_workspace_filter ? 
-              "${lookup(local.log_filter_map, "workspace_only")}" : (
-                "${lookup(local.log_filter_map, "k8s_workspace_combined")}"
-              )
+  log_filter = length(var.custom_filter) > 0 ? (var.custom_filter) : (
+    !var.k8s_filter && !var.google_workspace_filter ? ("${lookup(local.log_filter_map, "default")}") : (
+      var.k8s_filter && !var.google_workspace_filter ?
+      "${lookup(local.log_filter_map, "k8s_only")}" : (
+        !var.k8s_filter && var.google_workspace_filter ?
+        "${lookup(local.log_filter_map, "workspace_only")}" : (
+          "${lookup(local.log_filter_map, "k8s_workspace_combined")}"
         )
       )
+    )
   )
 
   folders = [

--- a/main.tf
+++ b/main.tf
@@ -50,9 +50,26 @@ locals {
         "projectViewer:${local.project_id}"
       ]
   })
-  log_filter = var.k8s_filter ? (
-    "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\")") : (
-  "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\")")
+
+  log_filter_map = {
+    default = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\")"
+    k8s_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\")"
+    workspace_only = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
+    k8s_workspace_combined = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.serviceName=\"k8s.io\") AND NOT (protoPayload.methodName:\"storage.objects\" AND NOT (protoPayload.serviceName:\"login.googleapis.com\")"
+  }
+
+  log_filter = length(var.custom_filter) > 0 ? ( var.custom_filter ) : ( 
+      !var.k8s_filter && !var.google_workspace_filter ? ("${lookup(local.log_filter_map, "default")}" ) : (
+        var.k8s_filter && !var.google_workspace_filter ? 
+          "${lookup(local.log_filter_map, "k8s_only")}" : (
+            !var.k8s_filter && var.google_workspace_filter ? 
+              "${lookup(local.log_filter_map, "workspace_only")}" : (
+                "${lookup(local.log_filter_map, "k8s_workspace_combined")}"
+              )
+        )
+      )
+  )
+
   folders = [
     (var.org_integration && local.exclude_folders) ? setsubtract(data.google_folders.my-org-folders[0].folders[*].name, var.folders_to_exclude) : toset([])
   ]

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -14,6 +14,8 @@ TEST_CASES=(
   examples/existing-service-account-org-level-audit-log/
   examples/organization-level-audit-log/
   examples/organization-level-audit-log-exclude-folders/
+  examples/organization-level-custom-filter/
+  examples/organization-level-google-workspace-filter/
   examples/project-level-audit-log/
 )
 

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -14,8 +14,8 @@ TEST_CASES=(
   examples/existing-service-account-org-level-audit-log/
   examples/organization-level-audit-log/
   examples/organization-level-audit-log-exclude-folders/
-  examples/organization-level-custom-filter/
-  examples/organization-level-google-workspace-filter/
+  examples/org-level-custom-filter/
+  examples/org-level-google-workspace-filter/
   examples/project-level-audit-log/
 )
 

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,18 @@ variable "k8s_filter" {
   description = "Filter out GKE logs from GCP Audit Log sinks.  Default is true"
 }
 
+variable "google_workspace_filter" {
+  type        = bool
+  default     = false
+  description = "Filter out Google Workspace login logs from GCP Audit Log sinks.  Default is false"
+}
+
+variable "custom_filter" {
+  type        = string
+  default     = ""
+  description = "Customer defined Audit Log filter which will supersede all other filter options when defined"
+}
+
 variable "folders_to_exclude" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## Summary

Introducing additional customization options for Log Filters following field experience. The most prominent would be the ability to arbitrarily specify a custom filter entirely when needed. Lack of this capability currently can result in vendor recommended drift from Terraform state in isolated scenarios.  

## How did you test this change?

Each combination of mapped filters was tested via a Terraform file configured to hit each code path. Examples were added for two expected, net new instances. 

Case - "default" - Expect k8s filtering and no workspace filtering
![image](https://user-images.githubusercontent.com/6099561/162019230-ba68824f-48ba-4976-b7e4-084fb032049e.png)

Case - "keep k8s, drop workspace" 
![image](https://user-images.githubusercontent.com/6099561/162019362-310c959c-5a29-4d51-a6d0-f4373e0b6aff.png)

Case - "custom filter"
![image](https://user-images.githubusercontent.com/6099561/162019406-dd18aff8-9909-4d3b-9d74-ea110a5ae169.png)

Case - "no k8s, workspace undefined (implicit keep)" 
![image](https://user-images.githubusercontent.com/6099561/162019487-6235661e-af11-4d15-b4b4-ad2656e4eba2.png)

Case = "drop k8s, drop workspace"
![image](https://user-images.githubusercontent.com/6099561/162019587-011dd09e-1411-4077-9965-4ec00b091a6d.png)




