### PR TITLE
fix: stop applying to project that are DELETE_REQUESTED

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,10 @@ locals {
 
   root_projects = [
     (var.org_integration && local.exclude_folders && var.include_root_projects) ? (
-      toset(data.google_projects.my-org-projects[0].projects[*].project_id)
+      toset([
+        for p in data.google_projects.my-org-projects[0].projects : p.project_id
+        if p.lifecycle_state != "DELETE_REQUESTED"
+        ])
       ) : (
       toset([])
     )


### PR DESCRIPTION
## Summary

Will filter out root projects whose lifecycle state is DELETE_REQUESTED from having resources created on them.
Ideally, this would have been done when getting the list of projects, but the google API does not allow that.

## How did you test this change?
Not sure how to test this yet...

## Issue
None.
