### PR TITLE
docs: update Lacework provider version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cloudresourcemanager.googleapis.com
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.1 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.4.0, < 5.0.0 |
-| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 0.2 |
+| <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 
 ## Providers
@@ -45,7 +45,7 @@ cloudresourcemanager.googleapis.com
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
-| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 0.2 |
+| <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
 


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0 in readme

[_Created by Sourcegraph batch change `darren.murray/terraform-readme`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-readme)