### PR TITLE
Permi the use of more recent google provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.1"
 
   required_providers {
-    google = ">= 4.4.0, < 4.41.0"
+    google = "~> 4.4"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
- `~> 4.4` is equivalent to `>= 4.4.0, < 5.0.0`.
- This matches the requirement of other `lacework-gcp` modules, e.g. https://github.com/lacework/terraform-gcp-config/blob/main/versions.tf#L5