### PR TITLE
chore: enable bucket_force_destroy by default

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -94,7 +94,6 @@ module "aws_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
   version = "~> 0.1"
 
-  bucket_force_destroy  = true
   use_existing_iam_role = true
   iam_role_name         = module.aws_config.iam_role_name
   iam_role_arn          = module.aws_config.iam_role_arn

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cloudresourcemanager.googleapis.com
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | n/a | `bool` | `false` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket) | `bool` | `true` | no |
 | <a name="input_bucket_labels"></a> [bucket\_labels](#input\_bucket\_labels) | Set of labels which will be added to the audit log bucket | `map(string)` | `{}` | no |
 | <a name="input_bucket_region"></a> [bucket\_region](#input\_bucket\_region) | The region where the new bucket will be created, valid values for Multi-regions are (EU, US or ASIA) alternatively you can set a single region or Dual-regions follow the naming convention as outlined in the GCP bucket locations documentation https://cloud.google.com/storage/docs/locations#available-locations\|string\|US\|false\| | `string` | `"US"` | no |
 | <a name="input_custom_bucket_name"></a> [custom\_bucket\_name](#input\_custom\_bucket\_name) | Override prefix based storage bucket name generation with custom name | `string` | `null` | no |

--- a/examples/environment-variables-project-level-audit-log/README.md
+++ b/examples/environment-variables-project-level-audit-log/README.md
@@ -1,7 +1,7 @@
 # Integrate GCP Project with Lacework using Environment Variables
 The following provides an example of integrating a Google Cloud Project with Lacework for Cloud Audit Log analysis and configuring the Terraform Provider for Google and the Terraform Provider for Lacework using environment variables.
 
-```
+```hcl
 // This template assumes the default configuration coming from the following
 // environment variables:
 //
@@ -39,9 +39,8 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_project_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.0"
-  bucket_force_destroy = true
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
 }
 ```
 

--- a/examples/environment-variables-project-level-audit-log/main.tf
+++ b/examples/environment-variables-project-level-audit-log/main.tf
@@ -26,6 +26,5 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_project_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
+  source = "../../"
 }

--- a/examples/existing-bucket-and-sink-org-level-audit-log/README.md
+++ b/examples/existing-bucket-and-sink-org-level-audit-log/README.md
@@ -15,12 +15,12 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                       = "lacework/audit-log/gcp"
-  version                      = "~> 3.0"
-  org_integration              = true
-  organization_id              = "my-organization-id"
-  existing_bucket_name         = "my-existing-bucket-name"
-  existing_sink_name           = "my-existing-sink-name"
+  source               = "lacework/audit-log/gcp"
+  version              = "~> 3.0"
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  existing_bucket_name = "my-existing-bucket-name"
+  existing_sink_name   = "my-existing-sink-name"
 }
 ```
 

--- a/examples/existing-bucket-and-sink-org-level-audit-log/main.tf
+++ b/examples/existing-bucket-and-sink-org-level-audit-log/main.tf
@@ -3,9 +3,9 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                       = "../../"
-  org_integration              = true
-  organization_id              = "my-organization-id"
-  existing_bucket_name         = "my-existing-bucket-name"
-  existing_sink_name           = "my-existing-sink-name"
+  source               = "../../"
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  existing_bucket_name = "my-existing-bucket-name"
+  existing_sink_name   = "my-existing-sink-name"
 }

--- a/examples/existing-service-account-org-level-audit-log/README.md
+++ b/examples/existing-service-account-org-level-audit-log/README.md
@@ -15,9 +15,9 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                       = "lacework/audit-log/gcp"
-  version                      = "~> 3.0"
-  bucket_force_destroy         = true
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
   use_existing_service_account = true
   service_account_name         = "my-service-account"
   service_account_private_key  = "ewogICJwcm9qZWN0X2lkIjogInNlY3JldCIsCiAgInByaXZhdGVfa2V5X2lkIjogIkdvdCB5YSEiLAogICJwcml2YXRlX2tleSI6ICJZb3Ugc2hvdWxkbid0IGJlIHJlYWRpbmcgdGhpcyBpbmZvcm1hdGlvbiA6LSkiLAogICJjbGllbnRfZW1haWwiOiAibm90QHZlcnkubmljZSIsCiAgImNsaWVudF9pZCI6ICIxMjM0Igp9Cg=="

--- a/examples/existing-service-account-org-level-audit-log/main.tf
+++ b/examples/existing-service-account-org-level-audit-log/main.tf
@@ -3,8 +3,8 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                       = "../../"
-  bucket_force_destroy         = true
+  source = "../../"
+
   use_existing_service_account = true
   service_account_name         = "my-service-account"
   service_account_private_key  = "ewogICJwcm9qZWN0X2lkIjogInNlY3JldCIsCiAgInByaXZhdGVfa2V5X2lkIjogIkdvdCB5YSEiLAogICJwcml2YXRlX2tleSI6ICJZb3Ugc2hvdWxkbid0IGJlIHJlYWRpbmcgdGhpcyBpbmZvcm1hdGlvbiA6LSkiLAogICJjbGllbnRfZW1haWwiOiAibm90QHZlcnkubmljZSIsCiAgImNsaWVudF9pZCI6ICIxMjM0Igp9Cg=="

--- a/examples/org-level-custom-filter/README.md
+++ b/examples/org-level-custom-filter/README.md
@@ -15,12 +15,12 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.0"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = "my-organization-id"
-  custom_filter        = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
+  org_integration = true
+  organization_id = "my-organization-id"
+  custom_filter   = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
 }
 ```
 

--- a/examples/org-level-custom-filter/main.tf
+++ b/examples/org-level-custom-filter/main.tf
@@ -7,11 +7,11 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
-  custom_filter        = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
+  source = "../../"
+
+  org_integration    = true
+  organization_id    = var.organization_id
+  enable_ubla        = true
+  lifecycle_rule_age = 7
+  custom_filter      = "(protoPayload.@type=type.googleapis.com/google.cloud.audit.AuditLog) AND NOT (protoPayload.methodName:\"storage.objects\") AND (logName =~ \"folders\" OR logName =~ \"organizations\")"
 }

--- a/examples/org-level-google-k8s-events/README.md
+++ b/examples/org-level-google-k8s-events/README.md
@@ -15,12 +15,14 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                    = "lacework/audit-log/gcp"
-  version                   = "~> 3.0"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = "my-organization-id"
-  k8s_filter           = false
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
+
+  org_integration    = true
+  organization_id    = "my-organization-id"
+  lifecycle_rule_age = 7
+  k8s_filter         = false
 }
 ```
 

--- a/examples/org-level-google-k8s-events/main.tf
+++ b/examples/org-level-google-k8s-events/main.tf
@@ -7,11 +7,11 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
-  k8s_filter           = false
+  source = "../../"
+
+  org_integration    = true
+  organization_id    = var.organization_id
+  enable_ubla        = true
+  lifecycle_rule_age = 7
+  k8s_filter         = false
 }

--- a/examples/org-level-google-workspace-events/README.md
+++ b/examples/org-level-google-workspace-events/README.md
@@ -15,12 +15,13 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source                    = "lacework/audit-log/gcp"
-  version                   = "~> 3.0"
-  bucket_force_destroy      = true
-  org_integration           = true
-  organization_id           = "my-organization-id"
-  google_workspace_filter   = false
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
+  org_integration         = true
+  organization_id         = "my-organization-id"
+  lifecycle_rule_age      = 7
+  google_workspace_filter = false
 }
 ```
 

--- a/examples/org-level-google-workspace-events/main.tf
+++ b/examples/org-level-google-workspace-events/main.tf
@@ -7,8 +7,8 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source                  = "../../"
-  bucket_force_destroy    = true
+  source = "../../"
+
   org_integration         = true
   organization_id         = var.organization_id
   enable_ubla             = true

--- a/examples/organization-level-audit-log-exclude-folders/README.md
+++ b/examples/organization-level-audit-log-exclude-folders/README.md
@@ -17,13 +17,13 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.4"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = "my-organization-id"
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.4"
+
+  org_integration    = true
+  organization_id    = "my-organization-id"
+  enable_ubla        = true
+  lifecycle_rule_age = 7
 
   folders_to_exclude = [
     "folders/578370918314",

--- a/examples/organization-level-audit-log-exclude-folders/main.tf
+++ b/examples/organization-level-audit-log-exclude-folders/main.tf
@@ -7,13 +7,13 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  project_id           = "abc-demo-project-123"
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source = "../../"
+
+  org_integration    = true
+  project_id         = "abc-demo-project-123"
+  organization_id    = var.organization_id
+  enable_ubla        = true
+  lifecycle_rule_age = 7
 
   folders_to_exclude = [
     "folders/123456789012",

--- a/examples/organization-level-audit-log-include-folders/README.md
+++ b/examples/organization-level-audit-log-include-folders/README.md
@@ -17,17 +17,17 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.4"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = "my-organization-id"
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.4"
+
+  org_integration    = true
+  project_id         = "abc-demo-project-123"
+  organization_id    = var.organization_id
+  lifecycle_rule_age = 7
 
   folders_to_include = [
-    "folders/578370918314",
-    "folders/1099205162015"
+    "folders/123456789012",
+    "folders/345678901234"
   ]
 }
 ```

--- a/examples/organization-level-audit-log-include-folders/main.tf
+++ b/examples/organization-level-audit-log-include-folders/main.tf
@@ -7,13 +7,12 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  project_id           = "abc-demo-project-123"
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source = "../../"
+
+  org_integration    = true
+  project_id         = "abc-demo-project-123"
+  organization_id    = var.organization_id
+  lifecycle_rule_age = 7
 
   folders_to_include = [
     "folders/123456789012",

--- a/examples/organization-level-audit-log/README.md
+++ b/examples/organization-level-audit-log/README.md
@@ -15,11 +15,13 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_organization_level_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.0"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = "my-organization-id"
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
+  org_integration    = true
+  organization_id    = "my-organization-id"
+  enable_ubla        = true
+  lifecycle_rule_age = 7
 }
 ```
 

--- a/examples/organization-level-audit-log/main.tf
+++ b/examples/organization-level-audit-log/main.tf
@@ -7,10 +7,10 @@ variable "organization_id" {
 }
 
 module "gcp_organization_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  org_integration      = true
-  organization_id      = var.organization_id
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source = "../../"
+
+  org_integration    = true
+  organization_id    = var.organization_id
+  enable_ubla        = true
+  lifecycle_rule_age = 7
 }

--- a/examples/project-level-audit-log-multi/README.md
+++ b/examples/project-level-audit-log-multi/README.md
@@ -25,7 +25,7 @@ variable "projects" {
 }
 
 module "gcp_audit_log" {
-  source = "lacework/audit-log/gcp"
+  source  = "lacework/audit-log/gcp"
   version = "~> 3.0"
 
   for_each   = var.projects

--- a/examples/project-level-audit-log-multi/main.tf
+++ b/examples/project-level-audit-log-multi/main.tf
@@ -6,8 +6,8 @@ provider "lacework" {}
 
 variable "projects" {
   description = "Map of project configuration with Lacework."
-  type        = map
-  default     = {
+  type        = map(any)
+  default = {
     project-id-1 = "first project",
     project-id-2 = "second project"
   }

--- a/examples/project-level-audit-log-multi/versions.tf
+++ b/examples/project-level-audit-log-multi/versions.tf
@@ -6,6 +6,4 @@ terraform {
       source = "lacework/lacework"
     }
   }
-
-
 }

--- a/examples/project-level-audit-log/README.md
+++ b/examples/project-level-audit-log/README.md
@@ -15,11 +15,10 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_project_level_audit_log" {
-  source               = "lacework/audit-log/gcp"
-  version              = "~> 3.0"
-  bucket_force_destroy = true
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+
+  lifecycle_rule_age = 7
 }
 ```
 

--- a/examples/project-level-audit-log/main.tf
+++ b/examples/project-level-audit-log/main.tf
@@ -3,8 +3,7 @@ provider "google" {}
 provider "lacework" {}
 
 module "gcp_project_level_audit_log" {
-  source               = "../../"
-  bucket_force_destroy = true
-  enable_ubla          = true
-  lifecycle_rule_age   = 7
+  source = "../../"
+
+  lifecycle_rule_age = 7
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,8 +61,9 @@ variable "custom_bucket_name" {
 }
 
 variable "bucket_force_destroy" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = true
+  description = "Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket)"
 }
 
 variable "bucket_region" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

When we use this module to automatically deploy and rollback changes. Users are having
constant issues trying to destroy the S3 bucket if it is not empty. To unblock this problem,
users need to turn on the `bucket_force_destroy` flag, and then do any modification that
requires a "destroy" operation.

By default, we should allow users to do these operations without the need to know about
this flag, if users does not wish to allow these buckets to be destroyed when they are not
empty, users should switch off the flag with `bucket_force_destroy = false`.

## How did you test this change?

After merge, we will run our internal pipeline https://github.com/lacework/terraform-customerdemo/pull/70

## Issue
https://lacework.atlassian.net/browse/GROW-1336
