### PR TITLE
Upgrade the google provider to 5.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.1"
 
   required_providers {
-    google = "~> 4.4"
+    google = "~> 5.6"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-audit-log/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The google v5 provider is out since October 2023 and provides much needed features for us. But we can't upgrade to it because of lacework.

This allows lacework to work with google v5.x
